### PR TITLE
Support PHP 8

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of `prooph/php-cs-fixer-config`.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2016-2020 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,26 @@ matrix:
     - php: 7.2
       env:
         - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.3
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.3
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 7.4
+      env:
+        - DEPENDENCIES=""
+        - TEST_COVERAGE=true
+    - php: 7.4
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
+    - php: 8.0
+      env:
+        - DEPENDENCIES=""
+    - php: 8.0
+      env:
+        - DEPENDENCIES="--prefer-lowest --prefer-stable"
 
 cache:
   directories:
@@ -31,7 +51,7 @@ before_script:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
-  - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
+  - if [[ $TEST_COVERAGE == 'true' ]]; then ./vendor/bin/php-cs-fixer fix -v --diff --dry-run ; fi
 
 after_success:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php vendor/bin/coveralls -v; fi

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     }
   ],
   "require": {
-    "php": "^7.1",
-    "friendsofphp/php-cs-fixer": "^2.16.3"
+    "php": "^7.1 || ^8.0",
+    "friendsofphp/php-cs-fixer": "^2.17.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.0",
+    "phpunit/phpunit": "^7.5 || ^9.5",
     "satooshi/php-coveralls": "^1.0"
   },
   "autoload": {

--- a/src/Prooph.php
+++ b/src/Prooph.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of `prooph/php-cs-fixer-config`.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2016-2020 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/ProophTest.php
+++ b/tests/ProophTest.php
@@ -2,8 +2,8 @@
 
 /**
  * This file is part of `prooph/php-cs-fixer-config`.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2016-2020 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
[php-cs-fixer binary](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702) is not ready yet for PHP 8 but php-cs-fixer can be run < PHP 8.0. So it's ready to merge.