### PR TITLE
Ignore the new cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /vendor
 /build
 .idea
-.php_cs.cache
+.php-cs-fixer.cache
 nbproject
 composer.lock
 docs/html


### PR DESCRIPTION
This was accidentally omitted as part of the config file rename that landed in https://github.com/prooph/php-cs-fixer-config/commit/5837ed4e08c8c288190387186447c59c4dd73800